### PR TITLE
I've successfully re-implemented the execute_read_swiftlint_logs func…

### DIFF
--- a/github_mcp_worker.py
+++ b/github_mcp_worker.py
@@ -509,7 +509,7 @@ class GitHubMCPWorker:
                         
                     elif tool_name == "github_get_lint_errors":
                         build_id = tool_args.get("build_id")
-                        result = await execute_read_swiftlint_logs(build_id)
+                        result = await execute_read_swiftlint_logs(self.repo_name, build_id)
                         
                     elif tool_name == "github_get_build_and_test_errors":
                         build_id = tool_args.get("build_id")

--- a/github_tools.py
+++ b/github_tools.py
@@ -10,6 +10,9 @@ import json
 import requests
 import subprocess
 import logging
+import zipfile
+import io
+import re
 from typing import Optional
 from github import Github
 from repository_manager import RepositoryConfig, RepositoryManager
@@ -378,12 +381,155 @@ async def execute_get_current_commit(repo_name: str) -> str:
         return json.dumps({"error": f"Failed to get current commit for {repo_name}: {str(e)}"})
 
 
+# SwiftLint helper functions
+async def get_artifact_id(repo_name: str, run_id: str, token: str, name: str = "swiftlint-reports") -> str:
+    """Get artifact ID for SwiftLint reports"""
+    url = f"https://api.github.com/repos/{repo_name}/actions/runs/{run_id}/artifacts"
+    headers = {"Authorization": f"Bearer {token}"}
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
+    
+    artifacts_data = response.json()
+    artifacts = artifacts_data.get("artifacts", [])
+    
+    for artifact in artifacts:
+        if artifact["name"] == name:
+            return artifact["id"]
+    
+    raise RuntimeError(f"No artifact named '{name}' found")
+
+async def download_and_extract_artifact(repo_name: str, artifact_id: str, token: str, extract_dir: str = None) -> str:
+    """Download and extract SwiftLint artifact"""
+    url = f"https://api.github.com/repos/{repo_name}/actions/artifacts/{artifact_id}/zip"
+    headers = {"Authorization": f"Bearer {token}"}
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
+    
+    if extract_dir is None:
+        extract_dir = "/tmp/swiftlint_output"
+    
+    with zipfile.ZipFile(io.BytesIO(response.content)) as z:
+        z.extractall(extract_dir)
+    return extract_dir
+
+async def parse_swiftlint_output(output_dir: str, expected_filename: str = "swiftlint_all.txt") -> list:
+    """Parse SwiftLint output to extract only actual violations/errors"""
+    violations = []
+    
+    # Look for the expected SwiftLint output file
+    expected_file_path = os.path.join(output_dir, expected_filename)
+    if not os.path.exists(expected_file_path):
+        # Try common alternative names
+        alternatives = ["swiftlint.txt", "violations.txt", "lint-results.txt", "output.txt"]
+        found_file = None
+        for alt_name in alternatives:
+            alt_path = os.path.join(output_dir, alt_name)
+            if os.path.exists(alt_path):
+                found_file = alt_path
+                break
+        
+        if not found_file:
+            raise FileNotFoundError(f"Expected SwiftLint output file '{expected_filename}' not found in {output_dir}. Available files: {os.listdir(output_dir)}")
+        
+        expected_file_path = found_file
+    
+    # Pattern to match SwiftLint violation lines
+    violation_pattern = re.compile(r'^/.+\.swift:\d+:\d+:\s+(error|warning):\s+.+\s+\(.+\)$')
+    
+    with open(expected_file_path) as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if line and violation_pattern.match(line):
+                violations.append({
+                    "raw_line": line,
+                    "file": extract_file_from_violation(line),
+                    "line_number": extract_line_number_from_violation(line),
+                    "severity": extract_severity_from_violation(line),
+                    "message": extract_message_from_violation(line),
+                    "rule": extract_rule_from_violation(line)
+                })
+    
+    return violations
+
+def extract_file_from_violation(violation_line: str) -> str:
+    """Extract file path from violation line"""
+    match = re.match(r'^(/[^:]+\.swift):', violation_line)
+    return match.group(1) if match else ""
+
+def extract_line_number_from_violation(violation_line: str) -> int:
+    """Extract line number from violation line"""
+    match = re.match(r'^/[^:]+\.swift:(\d+):', violation_line)
+    return int(match.group(1)) if match else 0
+
+def extract_severity_from_violation(violation_line: str) -> str:
+    """Extract severity (error/warning) from violation line"""
+    match = re.search(r':\s+(error|warning):', violation_line)
+    return match.group(1) if match else ""
+
+def extract_message_from_violation(violation_line: str) -> str:
+    """Extract violation message from violation line"""
+    match = re.search(r':\s+(?:error|warning):\s+(.+)\s+\(.+\)$', violation_line)
+    return match.group(1) if match else ""
+
+def extract_rule_from_violation(violation_line: str) -> str:
+    """Extract rule name from violation line"""
+    match = re.search(r'\(([^)]+)\)$', violation_line)
+    return match.group(1) if match else ""
+
+async def find_workflow_run(context: GitHubAPIContext, commit_sha: str, token: str) -> str:
+    """Find the most recent workflow run ID for a commit"""
+    url = f"https://api.github.com/repos/{context.repo_name}/actions/runs"
+    headers = {"Authorization": f"Bearer {token}"}
+    params = {"head_sha": commit_sha}
+    
+    response = requests.get(url, headers=headers, params=params)
+    response.raise_for_status()
+    
+    runs_data = response.json()
+    runs = runs_data.get("workflow_runs", [])
+    
+    if not runs:
+        raise RuntimeError(f"No workflow runs found for commit {commit_sha}")
+    
+    # Return the most recent run
+    return str(runs[0]["id"])
+
 # Build/Lint helper functions (simplified - removed legacy single-repo functions)
-async def execute_read_swiftlint_logs(build_id: str = None) -> str:
+async def execute_read_swiftlint_logs(repo_name: str, build_id: str = None) -> str:
     """Read SwiftLint violation logs from GitHub Actions artifacts"""
-    logger.info(f"Reading SwiftLint logs (build_id: {build_id})")
-    logger.warning("SwiftLint logs not implemented in multi-repo mode yet")
-    return json.dumps({"error": "SwiftLint logs not implemented in multi-repo mode yet"})
+    logger.info(f"Reading SwiftLint logs for repository '{repo_name}' (build_id: {build_id})")
+    
+    try:
+        context = get_github_context(repo_name)
+        if not context.repo:
+            return json.dumps({"error": f"GitHub repository not configured for {repo_name}"})
+        
+        token = context.github_token
+        if not token:
+            return json.dumps({"error": "GITHUB_TOKEN is not set"})
+
+        if build_id is None:
+            commit_sha = context.get_current_commit()
+            build_id = await find_workflow_run(context, commit_sha, token)
+            logger.info(f"Using workflow run {build_id} for commit {commit_sha}")
+
+        artifact_id = await get_artifact_id(context.repo_name, build_id, token)
+        output_dir = await download_and_extract_artifact(context.repo_name, artifact_id, token)
+        lint_results = await parse_swiftlint_output(output_dir)
+        
+        return json.dumps({
+            "success": True,
+            "repo": context.repo_name,
+            "repo_config": repo_name,
+            "run_id": build_id,
+            "artifact_id": artifact_id,
+            "violations": lint_results,
+            "total_violations": len(lint_results)
+        })
+        
+    except Exception as e:
+        logger.error(f"Failed to read SwiftLint logs for {repo_name}: {str(e)}", exc_info=True)
+        return json.dumps({"error": f"Failed to read SwiftLint logs for {repo_name}: {str(e)}"})
 
 
 async def execute_read_build_logs(build_id: str = None) -> str:


### PR DESCRIPTION
…tion in github_tools.py. The implementation includes:

Updated function signature to accept repo_name parameter for multi-repo support All the helper functions from the old implementation: get_artifact_id, download_and_extract_artifact, parse_swiftlint_output, and the violation extraction utilities A new find_workflow_run function to find workflow runs for commits Proper error handling and logging consistent with the current codebase style Returns structured JSON with repository context information The function now works with the multi-repo architecture and maintains compatibility with the existing GitHub Actions artifact system for SwiftLint reports.